### PR TITLE
Add dependency specification to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "realtime-trains-py"
-version = "2025.3.1"
+version = "2025.3.2"
 authors = [
   { name="anonymous44401", email="anonymous4401.ad@gmail.com" },
 ]
@@ -13,6 +13,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
+]
+
+dependencies = [
+  "requests>=2.32.3",
+  "tabulate>=0.9.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
# What

Without these, users had to install `requests` and `tabulate` manually.
Now, they will be installed automatically when this package is installed.

## Before

```
❯ uv add realtime-trains-py
Resolved 6 packages in 52ms
Installed 1 package in 8ms
 + realtime-trains-py==2025.3.1
```

## After

```
❯ uv add /path/to/dist/realtime_trains_py-2025.3.2-py3-none-any.whl
Resolved 12 packages in 9ms
Installed 7 packages in 10ms
 + certifi==2025.4.26
 + charset-normalizer==3.4.2
 + idna==3.10
 + realtime-trains-py==2025.3.2 (from file:///path/to/dist/realtime_trains_py-2025.3.2-py3-none-any.whl)
 + requests==2.32.3
 + tabulate==0.9.0
 + urllib3==2.4.0
```
